### PR TITLE
Bug fix: Wrong ouptut size due to wrong amount of padding in transposed convolutions with odd stride

### DIFF
--- a/agc/model.py
+++ b/agc/model.py
@@ -430,7 +430,7 @@ class AGC(PreTrainedModel):
 
         if self.config.vae:
             mean, scale = raw_latent.chunk(2, dim=1)
-            raw_latent = vae_sample(mean, scale)[0]
+            raw_latent = vae_sample(mean, scale)[0] if self.training else mean
 
         if not self.continuous:
             z = self.quantizer.forward(raw_latent)[0]

--- a/agc/model.py
+++ b/agc/model.py
@@ -1,5 +1,5 @@
 import torch
-from torch import nn, Tensor, FloatTensor, LongTensor
+from torch import nn, Tensor
 from torch.nn.utils.parametrizations import weight_norm
 import torch.nn.functional as F
 import math
@@ -43,10 +43,10 @@ class VectorQuantize(nn.Module):
 
         return z_q, commitment_loss, codebook_loss, indices, z_e
 
-    def embed_code(self, embed_id: LongTensor):
+    def embed_code(self, embed_id: Tensor):
         return F.embedding(embed_id, self.codebook.weight)
 
-    def decode_code(self, embed_id: LongTensor):
+    def decode_code(self, embed_id: Tensor):
         return self.embed_code(embed_id).transpose(1, 2)
 
     def decode_latents(self, latents: Tensor):
@@ -440,7 +440,7 @@ class AGC(PreTrainedModel):
 
         return z
 
-    def decode(self, z: FloatTensor | LongTensor) -> Tensor:
+    def decode(self, z: Tensor) -> Tensor:
         """Decode quantized codes and return audio data"""
 
         if not self.continuous:

--- a/agc/model.py
+++ b/agc/model.py
@@ -272,6 +272,7 @@ class DecoderBlock(nn.Module):
                 kernel_size=2 * stride,
                 stride=stride,
                 padding=math.ceil(stride / 2),
+                output_padding=0 if stride % 2 == 0 else 1
             ),
             ResidualUnit(output_dim, dilation=1),
             ResidualUnit(output_dim, dilation=3),

--- a/agc/model.py
+++ b/agc/model.py
@@ -140,12 +140,9 @@ class ResidualVectorQuantize(nn.Module):
 
     def from_indices(self, z: torch.Tensor):
         z_q = 0.0
-        z_p = []
         n_codebooks = z.shape[1]
         for i in range(n_codebooks):
             z_p_i = self.quantizers[i].decode_code(z[:, i, :])
-            z_p.append(z_p_i)
-
             z_q_i = self.quantizers[i].out_proj(z_p_i)
             z_q = z_q + z_q_i
         return z_q

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/AudiogenAI/agc",
     packages=find_packages(),
+    package_data={"agc": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3.10",
         "License :: Other/Proprietary License",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="audiogen-agc",
-    version="0.0.1",
+    version="0.0.2",
     author="Elio Pascarelli",
     author_email="elio@audiogen.co",
     description="Audiogen Codec",


### PR DESCRIPTION
Made 4 changes (in order of importance):
* 0c48ac85640f7a23171aaf2c38048e9885bade06 fixes the issue of the model not producing the same output length as the input. Curently, for instance, the example in the readme will receive a 1-sec input (48000 samples) and return a 47936 output (for discrete model). Fix is tested in pytorch 2.1+cu12.1 for both discrete and continuous models. It will work in most cases (particularly for any examples where num_samples in input is divisible by hop_length), especifically, if the conv stride is even and input_length (to the conv) is divisible by the stride, or stride is odd and input_length + 1 is not divisible by it.
* 825d106319960841bc7addbca71f8d5a281d4b71 disables the VAE sampling if the model is in eval mode. Seems logical to have repeatable reconstructions.
* f9392111116b124f943a125c66677362b9475c30 makes it mypy compliant
* 7382cb2f37980b22ce3302ffd5af7425fb0bd53f gets rid of global imports (replaces Tensor with torch.Tensor, PretrainedModel -> transformers.Pretrainedmodel and PretrainedConfig-> transformers.PretrainedConfig)