### PR TITLE
Bugfix: fix inconsistent shapes between input and output.

### DIFF
--- a/agc/model.py
+++ b/agc/model.py
@@ -272,6 +272,7 @@ class DecoderBlock(nn.Module):
                 kernel_size=2 * stride,
                 stride=stride,
                 padding=math.ceil(stride / 2),
+                output_padding= stride % 2,
             ),
             ResidualUnit(output_dim, dilation=1),
             ResidualUnit(output_dim, dilation=3),


### PR DESCRIPTION
Decoder produced output shapes that were inconsistent with the original input of the encoder.

## How to reproduce:
Run the code snippet from the readme:
```
from agc import AGC
import torch
agc = AGC.from_pretrained("Audiogen/agc-continuous") # or "agc-discrete"
audio = torch.randn(1, 2, 480000) # 48khz stereo
z = agc.encode(audio) # (1, 32, 6000) or (1, 24, 3000)
reconstructed_audio = agc.decode(z) # (1, 2, 480000)
print(reconstructed_audio.shape)
```
`reconstructed_audio.shape` is `[1, 2, 479992]`

## Identify the issue
Run:
```
from torchinfo import summary
print(summary(agc.decoder, (1, 32, 6000)))
```
Notice that `DecoderBlock: 2-3` produces output of shape `[1, 384, 359999]`. This signals some type of inconsistency with padding.

## Fix
When operating on strides that are odd, the `ConvTranspose1d` operator should apply extra output padding to keep shapes consistent after convolution + transposed convolution.
Adding `output_padding = stride % 2` to the arguments of `WNConvTranspose1d` in the `DecoderBlock` module fixes the issue. 
Now:
```
audio = torch.randn(1, 2, 480000)
z = agc.encode(audio)
reconstructed_audio = agc.decode(z)
print(reconstructed_audio.shape)
```
prints the correct shape of `[1, 2, 480000]`.